### PR TITLE
Add flake8 & pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# Match the Black line length (default 88),
+# rather than using the flake8 default of 79:
+max-line-length = 88
+extend-ignore = E203, W503
+ignore = E127, E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        language_version: python3.9
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        # args: ["--profile", "black", "--filter-files"]
+        additional_dependencies: [toml]
+        files: \.py$
+        language_version: python3.9
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        language_version: python3.9
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-toml
+      - id: check-yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,15 @@ tensorflow = "^2.9.1"
 pytest = "^5.2"
 black = {version = "^22.6.0", allow-prereleases = true}
 isort = "^5.10.1"
+pre-commit = "^2.20.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3


### PR DESCRIPTION
`flake8` is annoying in that it can't be configured inside `pyproject.toml`. Config is in `.flake8` right now, may want to move to using tox once we have some actual tests.  